### PR TITLE
Improve card validation and deduplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ interface.
   saved to disk and restored on launch using the new `PersistenceController`.
 - **Actionable insights** – A summary section highlights card totals, combined
   balances, and average balances for a quick health check.
+- **Safer data entry** – Built-in BIN prefix validation enforces a six-digit,
+  numeric prefix and prevents duplicate card numbers from being stored.
 - **Activity log** – Every important event (server activity, client responses,
   generation outcomes, and administrative actions) is recorded with timestamps.
 - **Management tools** – Clear the saved cards or wipe the activity log directly


### PR DESCRIPTION
## Summary
- add BIN prefix sanitisation with inline validation messaging and button gating
- prevent duplicate card numbers by deduplicating stored data and logging skipped inserts
- document the safer data entry workflow in the README

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68faabc57ad483279010f89e2bd44eec