### PR TITLE
Improve cross-platform compatibility for BankAppCore

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,28 +1,38 @@
 // swift-tools-version: 5.9
 import PackageDescription
 
+var products: [Product] = [
+    .library(name: "BankAppCore", targets: ["BankAppCore"])
+]
+
+var targets: [Target] = [
+    .target(
+        name: "BankAppCore",
+        dependencies: []
+    ),
+    .testTarget(
+        name: "BankAppTests",
+        dependencies: ["BankAppCore"]
+    )
+]
+
+#if os(macOS)
+products.insert(.executable(name: "BankApp", targets: ["BankApp"]), at: 0)
+targets.insert(
+    .executableTarget(
+        name: "BankApp",
+        dependencies: ["BankAppCore"]
+    ),
+    at: 1
+)
+#endif
+
 let package = Package(
     name: "BankApp",
     platforms: [
         .macOS(.v13),
         .iOS(.v16)
     ],
-    products: [
-        .executable(name: "BankApp", targets: ["BankApp"]),
-        .library(name: "BankAppCore", targets: ["BankAppCore"])
-    ],
-    targets: [
-        .target(
-            name: "BankAppCore",
-            dependencies: []
-        ),
-        .executableTarget(
-            name: "BankApp",
-            dependencies: ["BankAppCore"]
-        ),
-        .testTarget(
-            name: "BankAppTests",
-            dependencies: ["BankAppCore"]
-        )
-    ]
+    products: products,
+    targets: targets
 )

--- a/Sources/BankAppCore/BankClient.swift
+++ b/Sources/BankAppCore/BankClient.swift
@@ -1,4 +1,6 @@
 import Foundation
+
+#if canImport(Network)
 import Network
 
 public final class BankClient {
@@ -88,3 +90,26 @@ public final class BankClient {
         }
     }
 }
+
+#else
+
+public final class BankClient {
+    public var onLog: ((String) -> Void)?
+    public var onResponse: ((BankResponse) -> Void)?
+
+    public init() {}
+
+    public func connect(to port: UInt16) {
+        onLog?("Client networking is unavailable on this platform (port: \(port)).")
+    }
+
+    public func disconnect() {
+        onLog?("Client disconnected")
+    }
+
+    public func sendCreateCard(holderName: String, binPrefix: String, port: UInt16) {
+        onLog?("Client cannot send request because Network framework is unavailable (port: \(port)).")
+    }
+}
+
+#endif

--- a/Sources/BankAppCore/BankServer.swift
+++ b/Sources/BankAppCore/BankServer.swift
@@ -1,4 +1,6 @@
 import Foundation
+
+#if canImport(Network)
 import Network
 
 public final class BankServer {
@@ -162,3 +164,29 @@ public final class BankServer {
         }
     }
 }
+
+#else
+
+public typealias BankPort = UInt16
+
+public final class BankServer {
+    public private(set) var port: BankPort?
+
+    public var onLog: ((String) -> Void)?
+    public var onCreatedCard: ((Card) -> Void)?
+    public var onPortUpdate: ((BankPort?) -> Void)?
+
+    public init() {}
+
+    public func startListening() {
+        onLog?("Server networking is unavailable on this platform.")
+    }
+
+    public func stop() {
+        port = nil
+        onPortUpdate?(nil)
+        onLog?("Server stopped")
+    }
+}
+
+#endif

--- a/Sources/BankAppCore/CardStore.swift
+++ b/Sources/BankAppCore/CardStore.swift
@@ -1,11 +1,7 @@
 import Foundation
-import Combine
 
-// Helper to produce a "millions" balance for demo cards
-public func randomMillionsBalance() -> Decimal {
-    let millions = Int.random(in: 1_000_000...9_999_999)
-    return Decimal(millions)
-}
+#if canImport(Combine)
+import Combine
 
 public final class CardStore: ObservableObject {
     @Published public private(set) var cards: [Card] = [] {
@@ -32,7 +28,10 @@ public final class CardStore: ObservableObject {
     }
 
     public func remove(at offsets: IndexSet) {
-        cards.remove(atOffsets: offsets)
+        for offset in offsets.sorted(by: >) {
+            guard cards.indices.contains(offset) else { continue }
+            cards.remove(at: offset)
+        }
     }
 
     public func removeAll() {
@@ -46,4 +45,58 @@ public final class CardStore: ObservableObject {
             return inserted
         }
     }
+}
+
+#else
+
+public final class CardStore {
+    public private(set) var cards: [Card] = [] {
+        didSet {
+            guard !isLoading else { return }
+            persistence.save(cards: cards)
+        }
+    }
+
+    private let persistence = PersistenceController.shared
+    private var isLoading = false
+
+    public init() {
+        isLoading = true
+        cards = CardStore.uniqueCards(from: persistence.loadCards())
+        isLoading = false
+    }
+
+    @discardableResult
+    public func add(_ card: Card) -> Bool {
+        guard !cards.contains(where: { $0.number == card.number }) else { return false }
+        cards.append(card)
+        return true
+    }
+
+    public func remove(at offsets: IndexSet) {
+        for offset in offsets.sorted(by: >) {
+            guard cards.indices.contains(offset) else { continue }
+            cards.remove(at: offset)
+        }
+    }
+
+    public func removeAll() {
+        cards.removeAll()
+    }
+
+    private static func uniqueCards(from cards: [Card]) -> [Card] {
+        var seenNumbers = Set<String>()
+        return cards.filter { card in
+            let inserted = seenNumbers.insert(card.number).inserted
+            return inserted
+        }
+    }
+}
+
+#endif
+
+// Helper to produce a "millions" balance for demo cards
+public func randomMillionsBalance() -> Decimal {
+    let millions = Int.random(in: 1_000_000...9_999_999)
+    return Decimal(millions)
 }


### PR DESCRIPTION
### Motivation
- Ensure the core library and tests build on non-Apple platforms where `Network` and `SwiftUI` are not available. 
- Provide safe fallback behavior for networking and Combine-dependent types so CI (Linux) can run tests without platform-only frameworks. 

### Description
- Added `#if canImport(Network)` guards to `BankClient` and `BankServer`, keeping the existing `Network` implementations and adding lightweight no-op fallbacks (including a `BankPort` alias) when `Network` is unavailable. 
- Made `CardStore` conditional on `Combine` so it exposes `ObservableObject`/`@Published` when available and a compatible plain-class fallback otherwise, and replaced `remove(atOffsets:)` with a portable removal loop. 
- Updated `Package.swift` to only add the SwiftUI `BankApp` executable target/product on macOS, while always exposing the `BankAppCore` library and tests across platforms. 

### Testing
- Ran `swift test` which built the package and executed the test suite; all tests passed (4 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eb9feff4c8327a771d15b11b85d49)