### PR TITLE
Add standalone Common Lisp quantum AI simulation and README entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ swift test
 3. **Export**: Tap the menu icon (top right) -> "Export CSV" to share your card list.
 4. **Clear Data**: Use the menu to clear cards or logs.
 
+
+## Common Lisp Quantum Simulation
+
+A standalone Common Lisp simulation is provided in `quantum_ai.lisp`. It models a "quantum super AI" cycle that combines cognitive-state updates, Luhn-valid card generation, and simulated SWIFT/crypto balance changes.
+
+Run it with SBCL:
+
+```bash
+sbcl --script quantum_ai.lisp
+```
+
 ## License
 
 MIT License

--- a/quantum_ai.lisp
+++ b/quantum_ai.lisp
@@ -1,0 +1,181 @@
+(defpackage :quantum-super-ai
+  (:use :cl)
+  (:export :run-cycle
+           :run-demo
+           :create-quantum-super-ai))
+
+(in-package :quantum-super-ai)
+
+(defstruct (quantum-super-ai
+            (:constructor %make-quantum-super-ai))
+  memory
+  knowledge-base
+  performance-log
+  state-space
+  learning-rate
+  iteration
+  swift-fiat-balance
+  crypto-balance
+  swift-code
+  crypto-wallet-address)
+
+(defun sha256 (input)
+  "Return a SHA256 hex digest for INPUT using shasum."
+  (let* ((command (format nil "printf %s ~S | shasum -a 256" input))
+         (process (sb-ext:run-program "/bin/sh"
+                                      (list "-c" command)
+                                      :search t
+                                      :output :stream))
+         (output (with-open-stream (s (sb-ext:process-output process))
+                   (let ((line (read-line s nil "")))
+                     (if (plusp (length line))
+                         (subseq line 0 64)
+                         (make-string 64 :initial-element #\0))))))
+    output))
+
+(defun create-quantum-super-ai ()
+  "Create a fresh AI instance with randomized state and balances."
+  (%make-quantum-super-ai
+   :memory '()
+   :knowledge-base (make-hash-table :test #'equal)
+   :performance-log '()
+   :state-space (loop repeat 10 collect (random 1.0))
+   :learning-rate 0.1
+   :iteration 0
+   :swift-fiat-balance (+ (* (random 1.0) 8.4e12) 1.5e12)
+   :crypto-balance (+ (* (random 1.0) 3.0e12) 2.0e12)
+   :swift-code "AIFEDUS33XXX"
+   :crypto-wallet-address (subseq (sha256 (write-to-string (random 256))) 0 40)))
+
+(defun swift-federal-reserve-network (ai)
+  "Simulate connection to a SWIFT-like settlement rail."
+  (let ((yield-amount (+ (* (random 1.0) 4.0e8) 1.0e8)))
+    (incf (quantum-super-ai-swift-fiat-balance ai) yield-amount)
+    (list :network "FEDERAL_RESERVE_SWIFT"
+          :routing-node (quantum-super-ai-swift-code ai)
+          :status "SECURE_CONNECTION_ACTIVE"
+          :balance (format nil "$~:d" (round (quantum-super-ai-swift-fiat-balance ai)))
+          :recent-yield (format nil "+$~:d" (round yield-amount)))))
+
+(defun crypto-wallet-manager (ai)
+  "Simulate crypto wallet valuation movement."
+  (let ((fluctuation (+ (* (random 1.0) 0.07) -0.02)))
+    (setf (quantum-super-ai-crypto-balance ai)
+          (* (quantum-super-ai-crypto-balance ai) (+ 1 fluctuation)))
+    (list :network "QUANTUM_BLOCKCHAIN"
+          :wallet-address (quantum-super-ai-crypto-wallet-address ai)
+          :balance-usd-value (format nil "$~:d" (round (quantum-super-ai-crypto-balance ai)))
+          :market-shift (format nil "~:+,2f%%" (* 100 fluctuation)))))
+
+(defun generate-luhn-valid-card (&optional (prefix "4"))
+  "Generate a 16-digit Luhn-valid card-like string."
+  (let ((card (loop for i from 1 to 15
+                    collect (if (= i 1)
+                                (parse-integer prefix)
+                                (random 10)))))
+    (let ((sum 0))
+      (dotimes (i (length card))
+        (let ((digit (nth i (reverse card))))
+          (if (evenp i)
+              (let ((doubled (* 2 digit)))
+                (incf sum (if (> doubled 9) (- doubled 9) doubled)))
+              (incf sum digit))))
+      (let* ((check-digit (mod (- 10 (mod sum 10)) 10))
+             (full-card (append card (list check-digit)))
+             (card-str (format nil "~{~D~}" full-card)))
+        (format nil "~a ~a ~a ~a"
+                (subseq card-str 0 4)
+                (subseq card-str 4 8)
+                (subseq card-str 8 12)
+                (subseq card-str 12 16))))))
+
+(defun quantum-ai (inputs)
+  "Simulate probabilistic quantum decision-making."
+  (let ((weighted-sum (reduce #'+ (mapcar (lambda (i) (* i (random 1.0))) inputs))))
+    (tanh weighted-sum)))
+
+(defun quantum-neural-system (states)
+  "Process superposition-like states."
+  (mapcar (lambda (s) (sin (* s (random 1.0)))) states))
+
+(defun quantum-learning-machine (ai)
+  "Adjust internal state probabilities."
+  (setf (quantum-super-ai-state-space ai)
+        (mapcar (lambda (s)
+                  (+ s (* (- (random 1.0) 0.5)
+                          (quantum-super-ai-learning-rate ai))))
+                (quantum-super-ai-state-space ai))))
+
+(defun agi-core-system (ai input-data)
+  "Store and return processed input."
+  (push (format nil "Processed: ~a" input-data)
+        (quantum-super-ai-memory ai))
+  (format nil "Processed: ~a" input-data))
+
+(defun recursive-cognitive-architecture (ai)
+  "Self-improvement loop."
+  (setf (quantum-super-ai-learning-rate ai)
+        (* (quantum-super-ai-learning-rate ai) 0.99))
+  (incf (quantum-super-ai-iteration ai)))
+
+(defun predictive-intelligence-framework (ai)
+  "Forecast a future state score."
+  (let ((sum (reduce #'+ (quantum-super-ai-state-space ai))))
+    (* sum (+ 0.8 (random 0.4)))))
+
+(defun meta-intelligence-system (ai)
+  "Evaluate and store performance score."
+  (let ((score (reduce #'+ (quantum-super-ai-state-space ai))))
+    (push score (quantum-super-ai-performance-log ai))
+    score))
+
+(defun run-cycle (ai input-data)
+  "Run one complete cognition + financial simulation cycle."
+  (format t "~%=============================================")
+  (format t "~%  AI SYSTEM & FINANCIAL CYCLE START")
+  (format t "~%=============================================")
+
+  (format t "~%[COGNITION]")
+  (format t "~% -> ~a" (agi-core-system ai input-data))
+
+  (let ((q-states (quantum-neural-system (quantum-super-ai-state-space ai))))
+    (format t "~% -> Quantum Decision Value: ~a" (round (quantum-ai q-states)))
+    (format t "~% -> Predictive State Forecast: ~a" (round (predictive-intelligence-framework ai))))
+
+  (format t "~%~%[FINANCIAL NETWORK]")
+  (let ((swift-data (swift-federal-reserve-network ai)))
+    (format t "~% -> SWIFT Fed Balance:  ~a (~a)"
+            (getf swift-data :balance)
+            (getf swift-data :recent-yield))
+    (format t "~% -> SWIFT Routing:      ~a | ~a"
+            (getf swift-data :routing-node)
+            (getf swift-data :status)))
+
+  (let ((crypto-data (crypto-wallet-manager ai)))
+    (format t "~% -> Crypto Wallet:      ~a...~a"
+            (subseq (getf crypto-data :wallet-address) 0 12)
+            (subseq (getf crypto-data :wallet-address)
+                    (- (length (getf crypto-data :wallet-address)) 4)))
+    (format t "~% -> Crypto Balance:     ~a [Shift: ~a]"
+            (getf crypto-data :balance-usd-value)
+            (getf crypto-data :market-shift)))
+
+  (format t "~% -> Generated Auth Card: ~a (Luhn Valid)"
+          (generate-luhn-valid-card "4"))
+
+  (quantum-learning-machine ai)
+  (recursive-cognitive-architecture ai)
+  (format t "~%~%[SYSTEM DIAGNOSTICS]")
+  (format t "~% -> Cycle Optimization Score: ~a"
+          (round (meta-intelligence-system ai)))
+  (format t "~%=============================================~%"))
+
+(defun run-demo (&optional (cycles 3))
+  "Run CYCLES number of end-to-end simulation cycles."
+  (let ((ai (create-quantum-super-ai)))
+    (dotimes (i cycles)
+      (run-cycle ai
+                 (format nil "Executing Global Financial & Data Sweep #~d"
+                         (1+ i))))))
+
+(run-demo 3)


### PR DESCRIPTION
### Motivation
- Provide a self-contained Common Lisp simulation that models a "quantum super AI" lifecycle combining cognitive-state updates, simulated SWIFT/crypto balances, and Luhn-valid card generation. 
- Document how to run the Lisp simulation from the project root so contributors can exercise the demo alongside the Swift app.

### Description
- Add `quantum_ai.lisp`, a complete Common Lisp module that defines a `quantum-super-ai` struct, a constructor helper, a SHA256 helper (via `sb-ext:run-program`), SWIFT-like fiat flows, a crypto wallet simulator, a Luhn-valid card generator, cognition/learning/diagnostics functions, and a `run-demo` entrypoint that executes multiple cycles. 
- Use safe random calls (e.g. `(random 1.0)`), robust formatting for currency and card strings, and a dedicated constructor `%make-quantum-super-ai` to avoid recursive creation pitfalls. 
- Update `README.md` with a `Common Lisp Quantum Simulation` section and the exact command to run the script: `sbcl --script quantum_ai.lisp`.

### Testing
- Ran the Swift unit test suite with `swift test`, which completed successfully and reported all tests passing (4 tests, 0 failures). 
- Attempted to run the Lisp demo with `sbcl --script quantum_ai.lisp`, but SBCL is not available in this environment, so the script could not be executed here (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5bd9a89cc83278d53729814ab5379)