### PR TITLE
Add Quantum-Entropic Strategist V3 Common Lisp simulation and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,18 @@ swift test
 4. **Clear Data**: Use the menu to clear cards or logs.
 
 
-## Common Lisp Quantum Simulation
+## Common Lisp Quantum Simulations
 
-A standalone Common Lisp simulation is provided in `quantum_ai.lisp`. It models a "quantum super AI" cycle that combines cognitive-state updates, Luhn-valid card generation, and simulated SWIFT/crypto balance changes.
+Two standalone Common Lisp simulations are included:
 
-Run it with SBCL:
+- `quantum_ai.lisp`: a "quantum super AI" cycle combining cognitive-state updates, Luhn-valid card generation, and simulated SWIFT/crypto balance changes.
+- `quantum_strat_v3.lisp`: a CLOS-based "Quantum-Entropic Strategist" with wave-function collapse simulation, context retrieval, entropic position sizing, and online weight updates.
+
+Run either script with SBCL:
 
 ```bash
 sbcl --script quantum_ai.lisp
+sbcl --script quantum_strat_v3.lisp
 ```
 
 ## License

--- a/quantum_strat_v3.lisp
+++ b/quantum_strat_v3.lisp
@@ -1,0 +1,204 @@
+;; ======================================================================
+;; COGNITIVE LAYER V3: QUANTUM-ENTROPIC STRATEGIST (COMPLETE)
+;; UPGRADES: CLOS Architecture, Wave-Function Collapse, Entropic Scaling
+;; ======================================================================
+
+(defpackage :quantum-strat
+  (:use :cl)
+  (:export :initialize-system
+           :run-quantum-cycle
+           :generate-quantum-key
+           :authenticate))
+
+(in-package :quantum-strat)
+
+;; --- 1. CLOS DEFINITIONS (STATE ENCAPSULATION) ---
+
+(defclass cognitive-core ()
+  ((epoch :initform 0 :accessor epoch)
+   (learning-rate :initform 0.08 :accessor learning-rate)
+   (neural-weights :initform '(0.24 0.78 0.52) :accessor neural-weights)
+   (knowledge-base :initarg :kb :accessor kb)))
+
+(defclass portfolio ()
+  ((balance :initform 1.15e77 :accessor balance)
+   (positions :initform nil :accessor positions)
+   (risk-coeff :initform 0.01 :accessor risk-coeff)))
+
+(defclass market-state ()
+  ((entropy :initform 0.1 :accessor entropy)
+   (signal-vector :initform '(0.0 0.0 0.0) :accessor signal-vector)))
+
+(defclass session ()
+  ((api-key :initarg :key :accessor api-key)
+   (auth-level :initform :omega-tier :accessor auth-level)))
+
+;; --- 2. GLOBAL ENVIRONMENT ---
+
+(defvar *core* nil)
+(defvar *port* nil)
+(defvar *market* nil)
+(defvar *session* nil)
+(defvar *api-registry* (make-hash-table :test 'equal))
+
+(defun initialize-system ()
+  "Bootstraps the V3 CLOS environment."
+  (setf *core* (make-instance 'cognitive-core
+                              :kb '((:id 1 :concept "Momentum"       :vector (0.8 0.2 0.1))
+                                    (:id 2 :concept "Mean Reversion" :vector (0.1 0.9 0.2))
+                                    (:id 3 :concept "Risk Parity"    :vector (0.3 0.3 0.9))
+                                    (:id 4 :concept "LLM-Sentiment"  :vector (0.5 0.5 0.5))
+                                    (:id 5 :concept "Black Swan"     :vector (0.9 0.1 0.8)))))
+  (setf *port* (make-instance 'portfolio))
+  (setf *market* (make-instance 'market-state))
+  (setf *session* nil)
+  (format t "[SYSTEM] V3 Quantum-Entropic Core Initialized.~%"))
+
+;; --- 3. AUTHENTICATION & LIQUIDITY ---
+
+(defun generate-quantum-key (user-id)
+  "Generates an entangled API key and stores it in the registry."
+  (let ((key (format nil "INF-Q-~A-~X" user-id (random 1000000000))))
+    (setf (gethash key *api-registry*) t)
+    (format t "[AUTH] Quantum Key Forged: ~A~%" key)
+    key))
+
+(defun authenticate (key)
+  "Validates key presence before wave-function collapse."
+  (if (gethash key *api-registry*)
+      (progn
+        (setf *session* (make-instance 'session :key key))
+        (format t "[SECURE] Session Established. Tier: ~A~%" (auth-level *session*)))
+      (error "QUANTUM COLLAPSE: Unauthorized Key Intrusion.")))
+
+;; --- 4. ADVANCED MATHEMATICS & SUPERPOSITION ---
+
+(defun dot-product (v1 v2)
+  (loop for x in v1 for y in v2 sum (* x y)))
+
+(defun magnitude (v)
+  (sqrt (loop for x in v sum (* x x))))
+
+(defun cosine-similarity (v1 v2)
+  (let ((mag (* (magnitude v1) (magnitude v2))))
+    (if (zerop mag) 0.0 (/ (dot-product v1 v2) mag))))
+
+(defun softmax (vec)
+  (let* ((exps (mapcar #'exp vec))
+         (sum (reduce #'+ exps)))
+    (mapcar (lambda (x) (/ x sum)) exps)))
+
+(defun collapse-wave-function (base-signal entropy-level)
+  "Applies entropic jitter to simulate evaluating all market states simultaneously."
+  (mapcar (lambda (x)
+            (let ((jitter (* (- (random 2.0) 1.0) entropy-level)))
+              (max 0.0 (min 1.0 (+ x jitter)))))
+          base-signal))
+
+;; --- 5. COGNITIVE ENGINE ---
+
+(defun retrieve-context (query-vec top-k)
+  (let ((scored-kb (mapcar (lambda (item)
+                             (append item
+                                     (list :score (cosine-similarity (getf item :vector)
+                                                                     query-vec))))
+                           (kb *core*))))
+    (subseq (sort scored-kb #'> :key (lambda (x) (getf x :score)))
+            0
+            (min top-k (length scored-kb)))))
+
+(defun neural-forward-pass (input-vector weights)
+  (/ 1 (+ 1 (exp (- (loop for i in input-vector for w in weights sum (* i w)))))))
+
+(defun multi-agent-consensus (signal)
+  "Internal V3 consensus logic using the triplet agent heuristic."
+  (let* ((weights '((0.9 0.1 0.1) (0.1 0.9 0.1) (0.4 0.4 0.4)))
+         (votes (mapcar (lambda (w) (dot-product signal w)) weights)))
+    (softmax votes)))
+
+(defun generate-omega-strategy (context)
+  (let ((top-concept (getf (first context) :concept))
+        (trust-score (cosine-similarity (getf (first context) :vector) '(1.0 1.0 1.0))))
+    (format nil "STRATEGY-OMEGA: ~A [Resonance: ~,2F%]"
+            (string-upcase top-concept)
+            (* trust-score 100))))
+
+(defun backpropagate (target-signal actual-output)
+  (let* ((error (- target-signal actual-output))
+         (lr (learning-rate *core*))
+         (new-weights (mapcar (lambda (w) (+ w (* lr error)))
+                              (neural-weights *core*))))
+    (setf (neural-weights *core*) new-weights)
+    (format t "[NEURAL] Synaptic weights adjusted. Delta: ~,4F~%" error)))
+
+;; --- 6. ENTROPIC EXECUTION LAYER ---
+
+(defun execute-quantum-trade (action base-amount confidence)
+  "Scales trade size dynamically based on market entropy (chaos)."
+  (unless *session* (error "Execution Denied: No Active Session."))
+  (let* ((current-entropy (entropy *market*))
+         (entropic-modifier (- 1.0 current-entropy))
+         (actual-amount (* base-amount confidence entropic-modifier))
+         (bal (balance *port*)))
+    (if (>= bal actual-amount)
+        (progn
+          (setf (balance *port*) (- bal actual-amount))
+          (format t "[LEDGER] ~A ~A units. Entropic Dampening: ~,2F~%"
+                  action
+                  (round actual-amount)
+                  entropic-modifier))
+        (format t "[LEDGER] Liquidity collapse. Cannot execute.~%"))))
+
+;; --- 7. MAIN RECURSIVE LOOP ---
+
+(defun run-quantum-cycle (api-key)
+  "The full loop: Sensing -> Collapse -> Reason -> Execute -> Learn"
+  (authenticate api-key)
+  (incf (epoch *core*))
+
+  ;; Simulate market chaos in [0, 0.4)
+  (setf (entropy *market*) (random 0.4))
+
+  (format t "~%==================================================~%")
+  (format t ">>> EPOCH ~A | ENTROPY LEVEL: ~,3F <<<~%" (epoch *core*) (entropy *market*))
+  (format t "==================================================~%")
+
+  (let* ((raw-signal (list (random 1.0) (random 1.0) (random 1.0)))
+         ;; 1. Wave Function Collapse
+         (observed-signal (collapse-wave-function raw-signal (entropy *market*)))
+
+         ;; 2. Knowledge Retrieval
+         (context (retrieve-context observed-signal 3))
+         (strat-msg (generate-omega-strategy context))
+
+         ;; 3. Agent & Neural Inference
+         (agent-opinion (multi-agent-consensus observed-signal))
+         (inference (neural-forward-pass observed-signal (neural-weights *core*)))
+
+         ;; 4. Scoring logic
+         (final-score (* inference (reduce #'+ agent-opinion))))
+
+    (format t "[REASONING] ~A~%" strat-msg)
+    (format t "[SIGNAL] Inference Coherence: ~,4F~%" inference)
+
+    ;; 5. Decision & Execution
+    (cond ((> final-score 0.7)
+           (execute-quantum-trade 'long-stake 1.0e12 final-score))
+          ((< final-score 0.3)
+           (execute-quantum-trade 'short-hedge 5.0e11 final-score))
+          (t
+           (format t "[HOLD] Signal resonance insufficient (~,4F)~%" final-score)))
+
+    ;; 6. Backpropagation (learning toward an idealized state)
+    (backpropagate 0.8 inference)))
+
+;; ======================================================================
+;; STARTUP SEQUENCE
+;; ======================================================================
+
+(initialize-system)
+
+(defparameter *v3-key* (generate-quantum-key "OVERLORD-01"))
+
+;; Run multiple cycles to observe entropic scaling and weight adjustments.
+(loop repeat 3 do (run-quantum-cycle *v3-key*))


### PR DESCRIPTION
### Motivation
- Provide a second Common Lisp simulation that implements a CLOS-based "Quantum-Entropic Strategist" to complement the existing `quantum_ai.lisp` simulation. 
- Offer a standalone script that models wave-function collapse, entropic position sizing, consensus + neural inference, and online weight updates for local experimentation.

### Description
- Add `quantum_strat_v3.lisp`, a CLOS implementation exposing `initialize-system`, `generate-quantum-key`, `authenticate`, and `run-quantum-cycle`, with classes for `cognitive-core`, `portfolio`, `market-state`, and `session`. 
- Implement math and cognitive primitives (`dot-product`, `cosine-similarity`, `softmax`, `collapse-wave-function`, `neural-forward-pass`, `multi-agent-consensus`, `backpropagate`) and an entropic execution layer with `execute-quantum-trade`. 
- Include a startup/demo sequence that initializes the system, forges a quantum key, and runs three cycles to demonstrate entropic scaling and weight updates. 
- Update `README.md` to document both `quantum_ai.lisp` and the new `quantum_strat_v3.lisp` and show the `sbcl --script` run commands.

### Testing
- Ran `swift test`, which completed successfully and executed 4 tests with 0 failures in ~1.11s. 
- Attempted to run `sbcl --script quantum_strat_v3.lisp`, but SBCL is not installed in the environment so the Lisp script could not be executed (command not found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c30fd4e08327ab802a117b29c63b)