### PR TITLE
Add card utilities: normalization, masking, and brand detection

### DIFF
--- a/Sources/BankAppCore/Luhn.swift
+++ b/Sources/BankAppCore/Luhn.swift
@@ -1,4 +1,8 @@
 public enum Luhn {
+    public static func normalizedDigits(from input: String) -> String {
+        input.filter { $0.isNumber }
+    }
+
     public static func checksumDigit(forPartial partial: String) -> Int? {
         guard partial.allSatisfy({ $0.isNumber }) else { return nil }
         let digits = partial.compactMap { Int(String($0)) }
@@ -18,7 +22,7 @@ public enum Luhn {
     }
 
     public static func isValid(_ number: String) -> Bool {
-        let onlyDigits = number.filter { $0.isNumber }
+        let onlyDigits = normalizedDigits(from: number)
         guard onlyDigits.count >= 2 else { return false }
         let digits = onlyDigits.compactMap { Int(String($0)) }
         var sum = 0
@@ -42,5 +46,42 @@ public enum Luhn {
         }
         guard let check = checksumDigit(forPartial: partial) else { return nil }
         return partial + String(check)
+    }
+
+    public static func masked(_ number: String, visibleSuffixCount: Int = 4, maskCharacter: Character = "*") -> String {
+        let digits = normalizedDigits(from: number)
+        guard !digits.isEmpty else { return "" }
+        guard visibleSuffixCount > 0 else { return String(repeating: maskCharacter, count: digits.count) }
+
+        let suffix = String(digits.suffix(visibleSuffixCount))
+        let maskedCount = max(0, digits.count - visibleSuffixCount)
+        let prefixMask = String(repeating: maskCharacter, count: maskedCount)
+        return prefixMask + suffix
+    }
+
+    public static func cardBrand(for number: String) -> String {
+        let digits = normalizedDigits(from: number)
+
+        if digits.hasPrefix("4") {
+            return "Visa"
+        }
+
+        if digits.count >= 2, let firstTwo = Int(digits.prefix(2)), (51...55).contains(firstTwo) {
+            return "Mastercard"
+        }
+
+        if digits.count >= 4, let firstFour = Int(digits.prefix(4)), (2221...2720).contains(firstFour) {
+            return "Mastercard"
+        }
+
+        if digits.hasPrefix("34") || digits.hasPrefix("37") {
+            return "American Express"
+        }
+
+        if digits.hasPrefix("6011") || digits.hasPrefix("65") {
+            return "Discover"
+        }
+
+        return "Unknown"
     }
 }

--- a/Tests/BankAppTests/LuhnTests.swift
+++ b/Tests/BankAppTests/LuhnTests.swift
@@ -3,19 +3,15 @@ import XCTest
 
 final class LuhnTests: XCTestCase {
     func testChecksumDigit() {
-        // Known valid Luhn sequences
-        // 7992739871 -> last digit 3
         XCTAssertEqual(Luhn.checksumDigit(forPartial: "7992739871"), 3)
-
-        // Simple case: 1 -> double -> 2 -> sum 2 -> mod 2 -> 10-2=8
         XCTAssertEqual(Luhn.checksumDigit(forPartial: "1"), 8)
     }
 
     func testIsValid() {
         XCTAssertTrue(Luhn.isValid("79927398713"))
-        XCTAssertFalse(Luhn.isValid("79927398710")) // Invalid checksum
-        XCTAssertFalse(Luhn.isValid("1")) // Too short
-        XCTAssertTrue(Luhn.isValid("18")) // 1 -> 2, sum 2+8=10, 0 mod 10 == 0
+        XCTAssertFalse(Luhn.isValid("79927398710"))
+        XCTAssertFalse(Luhn.isValid("1"))
+        XCTAssertTrue(Luhn.isValid("18"))
     }
 
     func testGenerateCardNumber() {
@@ -25,5 +21,25 @@ final class LuhnTests: XCTestCase {
         XCTAssertTrue(generated!.hasPrefix(prefix))
         XCTAssertEqual(generated!.count, 16)
         XCTAssertTrue(Luhn.isValid(generated!))
+    }
+
+    func testNormalizeDigits() {
+        XCTAssertEqual(Luhn.normalizedDigits(from: "4000 1234-5678 9010"), "4000123456789010")
+        XCTAssertEqual(Luhn.normalizedDigits(from: "abc"), "")
+    }
+
+    func testMaskedNumber() {
+        XCTAssertEqual(Luhn.masked("4000123412341234"), "************1234")
+        XCTAssertEqual(Luhn.masked("4000-1234", visibleSuffixCount: 2), "******34")
+        XCTAssertEqual(Luhn.masked("40001234", visibleSuffixCount: 0), "********")
+    }
+
+    func testCardBrandDetection() {
+        XCTAssertEqual(Luhn.cardBrand(for: "4111111111111111"), "Visa")
+        XCTAssertEqual(Luhn.cardBrand(for: "5555555555554444"), "Mastercard")
+        XCTAssertEqual(Luhn.cardBrand(for: "2223003122003222"), "Mastercard")
+        XCTAssertEqual(Luhn.cardBrand(for: "378282246310005"), "American Express")
+        XCTAssertEqual(Luhn.cardBrand(for: "6011111111111117"), "Discover")
+        XCTAssertEqual(Luhn.cardBrand(for: "999999"), "Unknown")
     }
 }


### PR DESCRIPTION
### Motivation
- Improve card-number handling by normalizing formatted inputs (spaces/dashes) before validation and generation.
- Provide safe display utilities so card numbers can be masked for UI/exports.
- Offer simple card-brand detection to allow downstream UI/logic to display or route by brand.

### Description
- Added `Luhn.normalizedDigits(from:)` to strip non-digit characters and used it from `isValid` for consistent input handling in `Sources/BankAppCore/Luhn.swift`.
- Implemented `Luhn.masked(_:visibleSuffixCount:maskCharacter:)` to produce masked card strings for safe display.
- Implemented `Luhn.cardBrand(for:)` with basic rules for Visa, Mastercard (including 2221–2720), American Express, and Discover, with a fallback of `Unknown`.
- Expanded unit tests in `Tests/BankAppTests/LuhnTests.swift` to cover normalization, masking, and brand detection in addition to existing checksum/validation/generation tests.

### Testing
- Ran `swift test` in the package root to execute the test suite.
- All tests passed: test run executed 7 tests with 0 failures (total duration ~1.1s).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f840638de08327b271bd107114edbe)