### PR TITLE
Improve sandbox card generation and UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.build/
+.swiftpm/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ This repository contains a SwiftUI banking application demo, structured as a Swi
 - **SwiftUI Dashboard**: Interactive controls to start/stop the server, generate cards, and view history.
 - **Networking**: TCP `BankServer` and `BankClient` demonstrating custom protocol handling.
 - **Luhn Validation**: Validates card numbers using the Luhn algorithm.
+- **Sandbox Card Generation**: Centralized test-card generator with brand presets, input sanitation, and explicit demo-only metadata.
 - **Persistence**: JSON-backed persistence for cards and logs.
 - **Metadata Tracking**: Captures and persists connection metadata (source IP, interface) for generated cards.
 - **CSV Export**: Export your card list to CSV for external use.
+- **Search & Summary**: Filter generated cards by holder, brand, or masked number and review brand/balance totals.
 - **Adaptive Layout**: Responsive UI that adapts to different screen sizes.
 
 ## Project Structure
@@ -55,10 +57,13 @@ swift test
 
 1. **Server**: Toggle "Start Server" to begin listening for connections.
 2. **Generate Cards**:
-   - **Locally**: Generates a card immediately on the device.
+   - Pick a sandbox test brand preset and adjust the BIN prefix if needed.
+   - **Locally**: Generates a demo card immediately on the device.
    - **Via Server**: Sends a request to the local TCP server, demonstrating the client-server loop.
-3. **Export**: Tap the menu icon (top right) -> "Export CSV" to share your card list.
-4. **Clear Data**: Use the menu to clear cards or logs.
+   - Generated records are demo/test data only and include sandbox metadata.
+3. **Search**: Filter the generated card list by holder name, brand, or masked number.
+4. **Export**: Tap the menu icon (top right) -> "Export CSV" to share your card list.
+5. **Clear Data**: Use the menu to clear cards or logs.
 
 
 ## Common Lisp Quantum Simulations

--- a/Sources/BankApp/BankApp.swift
+++ b/Sources/BankApp/BankApp.swift
@@ -24,7 +24,9 @@ struct ContentView: View {
     @State private var client = BankClient()
 
     @State private var holderName = "Alice Example"
-    @State private var binPrefix = "400000"
+    @State private var selectedBrand: CardBrand = .visa
+    @State private var binPrefix = CardBrand.visa.defaultTestPrefix
+    @State private var searchText = ""
 
     @State private var isServerRunning = false
     @State private var logs: [LogEntry] = PersistenceController.shared.loadLogEntries()
@@ -35,19 +37,20 @@ struct ContentView: View {
     private let logLimit = 200
 
     private var binValidationMessage: String? {
-        if binPrefix.isEmpty {
-            return "Enter a BIN prefix to get started."
-        }
-        if !binPrefix.allSatisfy({ $0.isNumber }) {
-            return "BIN prefix must contain digits only."
-        }
-        if binPrefix.count != 6 {
-            return "BIN prefixes are typically 6 digits long."
-        }
-        return nil
+        CardGenerator.validationMessage(forPrefix: binPrefix)
     }
 
     private var isBinValid: Bool { binValidationMessage == nil }
+
+    private var filteredCards: [Card] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !query.isEmpty else { return store.cards }
+        return store.cards.filter { card in
+            card.displayName.lowercased().contains(query)
+                || card.maskedNumber.contains(query)
+                || card.brandName.lowercased().contains(query)
+        }
+    }
 
     private static let logFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -152,6 +155,21 @@ struct ContentView: View {
 
     private var cardCreationPanel: some View {
         VStack(spacing: 12) {
+            Text(CardGenerator.testDataNotice)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            Picker("Test Brand", selection: $selectedBrand) {
+                ForEach(CardBrand.selectableTestBrands) { brand in
+                    Text(brand.rawValue).tag(brand)
+                }
+            }
+            .pickerStyle(.segmented)
+            .onChange(of: selectedBrand) { newBrand in
+                binPrefix = newBrand.defaultTestPrefix
+            }
+
             HStack {
                 TextField("Card Holder", text: $holderName)
                     .textFieldStyle(.roundedBorder)
@@ -159,8 +177,7 @@ struct ContentView: View {
                     .textFieldStyle(.roundedBorder)
                     .frame(width: 140)
                     .onChange(of: binPrefix) { newValue in
-                        let filtered = newValue.filter { $0.isNumber }
-                        let limited = String(filtered.prefix(6))
+                        let limited = String(CardGenerator.sanitizedPrefix(newValue).prefix(6))
                         if limited != newValue {
                             binPrefix = limited
                         }
@@ -194,19 +211,22 @@ struct ContentView: View {
                         appendLog(message: "Local generation failed: invalid BIN prefix")
                         return
                     }
-                    guard let cardNumber = Luhn.generateCardNumber(prefix: binPrefix) else {
-                        appendLog(message: "Local generation failed: invalid BIN prefix")
-                        return
-                    }
-                    let cvv = String(format: "%03d", Int.random(in: 0...999))
-                    let expiryMonth = Int.random(in: 1...12)
-                    let expiryYear = Calendar.current.component(.year, from: Date()) + Int.random(in: 1...5)
-                    let balance = randomMillionsBalance()
-                    let card = Card(holderName: holderName, prefix: binPrefix, number: cardNumber, expiryMonth: expiryMonth, expiryYear: expiryYear, cvv: cvv, balance: balance)
-                    if store.add(card) {
-                        appendLog(message: "Locally generated card for \(holderName)")
-                    } else {
-                        appendLog(message: "Skipped local generation: duplicate card number")
+                    do {
+                        let card = try CardGenerator.makeCard(
+                            options: CardGenerationOptions(
+                                holderName: holderName,
+                                binPrefix: binPrefix,
+                                brand: selectedBrand,
+                                metadata: ["sourceType": "local"]
+                            )
+                        )
+                        if store.add(card) {
+                            appendLog(message: "Locally generated \(selectedBrand.rawValue) sandbox card for \(card.displayName)")
+                        } else {
+                            appendLog(message: "Skipped local generation: duplicate card number")
+                        }
+                    } catch {
+                        appendLog(message: "Local generation failed: \(error.localizedDescription)")
                     }
                 }
                 .buttonStyle(.bordered)
@@ -224,6 +244,7 @@ struct ContentView: View {
                     if let average = averageBalance() {
                         summaryRow(title: "Average balance", value: formattedBalance(average))
                     }
+                    summaryRow(title: "Brands", value: brandSummary())
                 }
             }
 
@@ -232,10 +253,20 @@ struct ContentView: View {
                     Text("No cards yet. Generate one to begin.")
                         .foregroundStyle(.secondary)
                 } else {
-                    ForEach(store.cards) { card in
+                    TextField("Search holder, brand, or masked number", text: $searchText)
+                        .textFieldStyle(.roundedBorder)
+
+                    if filteredCards.isEmpty {
+                        Text("No cards match your search.")
+                            .foregroundStyle(.secondary)
+                    }
+
+                    ForEach(filteredCards) { card in
                         VStack(alignment: .leading, spacing: 4) {
-                            Text(card.holderName)
+                            Text(card.displayName)
                                 .font(.headline)
+                            Text("Brand: \(card.brandName)")
+                                .foregroundStyle(.secondary)
                             Text("Number: \(masked(card.number))")
                             Text("Expiry: \(card.expiryMonth)/\(card.expiryYear)  CVV: \(card.cvv)")
                                 .foregroundStyle(.secondary)
@@ -246,7 +277,7 @@ struct ContentView: View {
                         }
                         .padding(.vertical, 6)
                     }
-                    .onDelete(perform: store.remove)
+                    .onDelete(perform: removeFilteredCards)
                 }
             }
 
@@ -329,6 +360,13 @@ struct ContentView: View {
         persistence.save(logEntries: logs)
     }
 
+    private func removeFilteredCards(at offsets: IndexSet) {
+        let idsToRemove = offsets.compactMap { offset in
+            filteredCards.indices.contains(offset) ? filteredCards[offset].id : nil
+        }
+        store.removeCards(withIDs: Set(idsToRemove))
+    }
+
     private func performClearAction(_ action: ClearAction) {
         switch action {
         case .cards:
@@ -349,6 +387,14 @@ struct ContentView: View {
         let total = totalBalance()
         let count = Decimal(store.cards.count)
         return total / count
+    }
+
+    private func brandSummary() -> String {
+        let grouped = Dictionary(grouping: store.cards, by: { $0.brandName })
+        return grouped
+            .map { "\($0.key): \($0.value.count)" }
+            .sorted()
+            .joined(separator: " • ")
     }
 
     private func trimLogsIfNeeded() {

--- a/Sources/BankAppCore/BankServer.swift
+++ b/Sources/BankAppCore/BankServer.swift
@@ -112,24 +112,13 @@ public final class BankServer {
                 return
             }
 
-            guard let bin = request.binPrefix, !bin.isEmpty, let holder = request.holderName, !holder.isEmpty else {
+            guard let rawBin = request.binPrefix, !rawBin.isEmpty, let rawHolder = request.holderName, !rawHolder.isEmpty else {
                 let response = BankResponse(status: "error", message: "Missing holder or BIN prefix", card: nil)
                 send(response: response, to: connection)
                 return
             }
 
-            guard let cardNumber = Luhn.generateCardNumber(prefix: bin) else {
-                let response = BankResponse(status: "error", message: "Unable to generate number", card: nil)
-                send(response: response, to: connection)
-                return
-            }
-
-            let cvv = String(format: "%03d", Int.random(in: 0...999))
-            let expiryMonth = Int.random(in: 1...12)
-            let expiryYear = Calendar.current.component(.year, from: Date()) + Int.random(in: 1...5)
-            let balance = randomMillionsBalance()
-
-            var metadata: [String: String] = [:]
+            var metadata: [String: String] = ["sourceType": "server"]
             if let endpoint = connection.endpoint {
                 metadata["source"] = "\(endpoint)"
             }
@@ -137,10 +126,18 @@ public final class BankServer {
                 metadata["interface"] = "\(currentPath.availableInterfaces.first?.name ?? "unknown")"
             }
 
-            let card = Card(holderName: holder, prefix: bin, number: cardNumber, expiryMonth: expiryMonth, expiryYear: expiryYear, cvv: cvv, balance: balance, metadata: metadata)
+            let options = CardGenerationOptions(holderName: rawHolder, binPrefix: rawBin, metadata: metadata)
+            let card: Card
+            do {
+                card = try CardGenerator.makeCard(options: options)
+            } catch {
+                let response = BankResponse(status: "error", message: error.localizedDescription, card: nil)
+                send(response: response, to: connection)
+                return
+            }
 
             onCreatedCard?(card)
-            onLog?("Generated card for \(holder) with BIN \(bin)")
+            onLog?("Generated sandbox card for \(card.displayName) with BIN \(card.prefix)")
 
             let response = BankResponse(status: "success", message: "Card created", card: card)
             send(response: response, to: connection)

--- a/Sources/BankAppCore/CardGenerator.swift
+++ b/Sources/BankAppCore/CardGenerator.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+public enum CardBrand: String, CaseIterable, Codable, Identifiable {
+    case visa = "Visa"
+    case mastercard = "Mastercard"
+    case americanExpress = "American Express"
+    case discover = "Discover"
+    case unknown = "Unknown"
+
+    public var id: String { rawValue }
+
+    public var defaultTestPrefix: String {
+        switch self {
+        case .visa:
+            return "400000"
+        case .mastercard:
+            return "555555"
+        case .americanExpress:
+            return "378282"
+        case .discover:
+            return "601111"
+        case .unknown:
+            return "999999"
+        }
+    }
+
+    public var cardNumberLength: Int {
+        switch self {
+        case .americanExpress:
+            return 15
+        default:
+            return 16
+        }
+    }
+
+    public static var selectableTestBrands: [CardBrand] {
+        [.visa, .mastercard, .americanExpress, .discover]
+    }
+}
+
+public struct CardGenerationOptions: Equatable {
+    public let holderName: String
+    public let binPrefix: String
+    public let brand: CardBrand?
+    public let balanceRange: ClosedRange<Int>
+    public let metadata: [String: String]
+
+    public init(holderName: String, binPrefix: String, brand: CardBrand? = nil, balanceRange: ClosedRange<Int> = 1_000_000...9_999_999, metadata: [String: String] = [:]) {
+        self.holderName = holderName
+        self.binPrefix = binPrefix
+        self.brand = brand
+        self.balanceRange = balanceRange
+        self.metadata = metadata
+    }
+}
+
+public enum CardGenerationError: LocalizedError, Equatable {
+    case emptyHolderName
+    case invalidPrefix
+    case unsupportedLength
+    case invalidBalanceRange
+
+    public var errorDescription: String? {
+        switch self {
+        case .emptyHolderName:
+            return "Enter a card holder name."
+        case .invalidPrefix:
+            return "BIN prefix must contain 1 to 12 digits."
+        case .unsupportedLength:
+            return "BIN prefix is too long for the selected brand."
+        case .invalidBalanceRange:
+            return "Balance range must contain positive values."
+        }
+    }
+}
+
+public enum CardGenerator {
+    public static let testDataNotice = "Demo test data only — generated numbers are for local development and must not be used as real payment credentials."
+
+    public static func sanitizedHolderName(_ holderName: String) -> String {
+        holderName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    public static func sanitizedPrefix(_ prefix: String) -> String {
+        String(prefix.filter { $0.isNumber }.prefix(12))
+    }
+
+    public static func validationMessage(forPrefix prefix: String, expectedLength: Int = 6) -> String? {
+        if prefix.isEmpty {
+            return "Enter a BIN prefix to get started."
+        }
+        if !prefix.allSatisfy({ $0.isNumber }) {
+            return "BIN prefix must contain digits only."
+        }
+        if prefix.count != expectedLength {
+            return "BIN prefixes are typically \(expectedLength) digits long."
+        }
+        return nil
+    }
+
+    public static func makeCard(options: CardGenerationOptions, calendar: Calendar = .current, now: Date = Date()) throws -> Card {
+        let holder = sanitizedHolderName(options.holderName)
+        guard !holder.isEmpty else { throw CardGenerationError.emptyHolderName }
+
+        let prefix = sanitizedPrefix(options.binPrefix)
+        guard !prefix.isEmpty, prefix == options.binPrefix, (1...12).contains(prefix.count) else {
+            throw CardGenerationError.invalidPrefix
+        }
+
+        let brand = options.brand ?? CardBrand(rawValue: Luhn.cardBrand(for: prefix)) ?? .unknown
+        let length = brand.cardNumberLength
+        guard prefix.count < length else { throw CardGenerationError.unsupportedLength }
+        guard options.balanceRange.lowerBound > 0, options.balanceRange.lowerBound <= options.balanceRange.upperBound else {
+            throw CardGenerationError.invalidBalanceRange
+        }
+
+        guard let cardNumber = Luhn.generateCardNumber(prefix: prefix, length: length) else {
+            throw CardGenerationError.unsupportedLength
+        }
+
+        let expiryMonth = Int.random(in: 1...12)
+        let currentYear = calendar.component(.year, from: now)
+        let expiryYear = currentYear + Int.random(in: 1...5)
+        let cvvWidth = brand == .americanExpress ? 4 : 3
+        let cvvUpperBound = Int(pow(10.0, Double(cvvWidth))) - 1
+        let cvv = String(format: "%0\(cvvWidth)d", Int.random(in: 0...cvvUpperBound))
+        let balance = Decimal(Int.random(in: options.balanceRange))
+
+        var metadata = options.metadata
+        metadata["brand"] = brand.rawValue
+        metadata["environment"] = "sandbox"
+        metadata["notice"] = testDataNotice
+
+        return Card(holderName: holder, prefix: prefix, number: cardNumber, expiryMonth: expiryMonth, expiryYear: expiryYear, cvv: cvv, balance: balance, metadata: metadata)
+    }
+}

--- a/Sources/BankAppCore/CardStore.swift
+++ b/Sources/BankAppCore/CardStore.swift
@@ -34,6 +34,10 @@ public final class CardStore: ObservableObject {
         }
     }
 
+    public func removeCards(withIDs ids: Set<Card.ID>) {
+        cards.removeAll { ids.contains($0.id) }
+    }
+
     public func removeAll() {
         cards.removeAll()
     }
@@ -78,6 +82,10 @@ public final class CardStore {
             guard cards.indices.contains(offset) else { continue }
             cards.remove(at: offset)
         }
+    }
+
+    public func removeCards(withIDs ids: Set<Card.ID>) {
+        cards.removeAll { ids.contains($0.id) }
     }
 
     public func removeAll() {

--- a/Sources/BankAppCore/Models.swift
+++ b/Sources/BankAppCore/Models.swift
@@ -24,8 +24,15 @@ public struct Card: Identifiable, Codable {
     }
 
     public var maskedNumber: String {
-        guard number.count > 4 else { return number }
-        return String(repeating: "*", count: max(0, number.count - 4)) + number.suffix(4)
+        Luhn.masked(number)
+    }
+
+    public var brandName: String {
+        metadata?["brand"] ?? Luhn.cardBrand(for: number)
+    }
+
+    public var displayName: String {
+        holderName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "Unnamed Holder" : holderName
     }
 
     public var isLikelyValid: Bool {

--- a/Tests/BankAppTests/CardGeneratorTests.swift
+++ b/Tests/BankAppTests/CardGeneratorTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import BankAppCore
+
+final class CardGeneratorTests: XCTestCase {
+    func testSanitizesPrefixForInteractiveEntry() {
+        XCTAssertEqual(CardGenerator.sanitizedPrefix(" 4000-00abc9999999"), "400000999999")
+    }
+
+    func testValidationMessageRequiresSixDigitBin() {
+        XCTAssertNil(CardGenerator.validationMessage(forPrefix: "400000"))
+        XCTAssertEqual(CardGenerator.validationMessage(forPrefix: "4000"), "BIN prefixes are typically 6 digits long.")
+        XCTAssertEqual(CardGenerator.validationMessage(forPrefix: "40A000"), "BIN prefix must contain digits only.")
+    }
+
+    func testMakeVisaSandboxCardAddsMetadataAndValidNumber() throws {
+        let card = try CardGenerator.makeCard(
+            options: CardGenerationOptions(
+                holderName: "  Test Holder  ",
+                binPrefix: CardBrand.visa.defaultTestPrefix,
+                brand: .visa,
+                balanceRange: 100...100,
+                metadata: ["sourceType": "unit-test"]
+            )
+        )
+
+        XCTAssertEqual(card.displayName, "Test Holder")
+        XCTAssertEqual(card.prefix, "400000")
+        XCTAssertEqual(card.number.count, 16)
+        XCTAssertEqual(card.cvv.count, 3)
+        XCTAssertEqual(card.balance, 100)
+        XCTAssertTrue(card.isLikelyValid)
+        XCTAssertEqual(card.brandName, CardBrand.visa.rawValue)
+        XCTAssertEqual(card.metadata?["environment"], "sandbox")
+        XCTAssertEqual(card.metadata?["sourceType"], "unit-test")
+    }
+
+    func testMakeAmericanExpressUsesFifteenDigitsAndFourDigitCVV() throws {
+        let card = try CardGenerator.makeCard(
+            options: CardGenerationOptions(
+                holderName: "Amex Tester",
+                binPrefix: CardBrand.americanExpress.defaultTestPrefix,
+                brand: .americanExpress
+            )
+        )
+
+        XCTAssertEqual(card.number.count, 15)
+        XCTAssertEqual(card.cvv.count, 4)
+        XCTAssertTrue(card.isLikelyValid)
+        XCTAssertEqual(card.brandName, CardBrand.americanExpress.rawValue)
+    }
+
+    func testRejectsUnsafeOrUnsupportedInput() {
+        XCTAssertThrowsError(try CardGenerator.makeCard(options: CardGenerationOptions(holderName: "", binPrefix: "400000"))) { error in
+            XCTAssertEqual(error as? CardGenerationError, .emptyHolderName)
+        }
+        XCTAssertThrowsError(try CardGenerator.makeCard(options: CardGenerationOptions(holderName: "A", binPrefix: "4000AB"))) { error in
+            XCTAssertEqual(error as? CardGenerationError, .invalidPrefix)
+        }
+    }
+}

--- a/Tests/BankAppTests/CardModelTests.swift
+++ b/Tests/BankAppTests/CardModelTests.swift
@@ -7,6 +7,12 @@ final class CardModelTests: XCTestCase {
         XCTAssertEqual(card.maskedNumber, "************7890")
     }
 
+    func testBrandAndDisplayNameFallbacks() {
+        let card = Card(holderName: "   ", prefix: "400000", number: "4111111111111111", expiryMonth: 12, expiryYear: 2030, cvv: "123", balance: 0)
+        XCTAssertEqual(card.displayName, "Unnamed Holder")
+        XCTAssertEqual(card.brandName, "Visa")
+    }
+
     func testValidityAndExpiry() {
         let validNumber = Luhn.generateCardNumber(prefix: "400000")!
         let card = Card(holderName: "A", prefix: "400000", number: validNumber, expiryMonth: 1, expiryYear: 2020, cvv: "123", balance: 0)


### PR DESCRIPTION
### Motivation
- Centralize and harden demo card generation to avoid duplicated logic and make generated numbers explicitly sandbox/test-only via metadata.
- Provide better interactive controls and feedback in the UI including brand presets, BIN sanitization, and search to make the demo easier to use and less error-prone.
- Make server and client generation share the same validation and generation paths so errors surface consistently and metadata is preserved.

### Description
- Add a new generator `Sources/BankAppCore/CardGenerator.swift` exposing `CardBrand`, `CardGenerationOptions`, `CardGenerationError`, and `CardGenerator.makeCard(...)` with brand-specific lengths/CVV, input sanitization, and demo-only metadata.
- Update the data model in `Sources/BankAppCore/Models.swift` to reuse `Luhn.masked(...)` and add `brandName` and `displayName` helpers for cleaner UI rendering.
- Replace ad-hoc generation in `Sources/BankAppCore/BankServer.swift` and the app local generation to use `CardGenerator`, and preserve connection metadata with a `sourceType` tag.
- Enhance the SwiftUI app in `Sources/BankApp/BankApp.swift` with a brand `Picker`, sandbox notice, shared BIN validation/sanitization via `CardGenerator`, search/filtering (`searchText` + `filteredCards`), brand summary (`brandSummary()`), and filtered deletion using `removeFilteredCards(...)`.
- Add `CardStore.removeCards(withIDs:)` in `Sources/BankAppCore/CardStore.swift` to support deleting records from filtered views and update persistence/CSV docs in `README.md`.
- Add unit tests `Tests/BankAppTests/CardGeneratorTests.swift` for the generator and extend `Tests/BankAppTests/CardModelTests.swift` to cover display/brand fallbacks, and add a `.gitignore`.

### Testing
- Ran the package test suite with `swift test` which executed 16 tests across `CardGeneratorTests`, `CardModelTests`, `LuhnTests`, and `PersistenceTests` and all tests passed (0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faeae304b88327b1d21e432e52f079)