### PR TITLE
Add card health analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ This repository contains a SwiftUI banking application demo, structured as a Swi
 - **Persistence**: JSON-backed persistence for cards and logs.
 - **Metadata Tracking**: Captures and persists connection metadata (source IP, interface) for generated cards.
 - **CSV Export**: Export your card list to CSV for external use.
-- **Search & Summary**: Filter generated cards by holder, brand, or masked number and review brand/balance totals.
+- **Search & Summary**: Filter generated cards by holder, brand, masked number, or health status and review brand/balance totals.
+- **Card Health Insights**: Highlights active, expiring-soon, expired, and invalid sandbox cards with attention counts.
 - **Adaptive Layout**: Responsive UI that adapts to different screen sizes.
 
 ## Project Structure
@@ -61,7 +62,7 @@ swift test
    - **Locally**: Generates a demo card immediately on the device.
    - **Via Server**: Sends a request to the local TCP server, demonstrating the client-server loop.
    - Generated records are demo/test data only and include sandbox metadata.
-3. **Search**: Filter the generated card list by holder name, brand, or masked number.
+3. **Search**: Filter the generated card list by holder name, brand, health status, or masked number.
 4. **Export**: Tap the menu icon (top right) -> "Export CSV" to share your card list.
 5. **Clear Data**: Use the menu to clear cards or logs.
 

--- a/Sources/BankApp/BankApp.swift
+++ b/Sources/BankApp/BankApp.swift
@@ -49,7 +49,12 @@ struct ContentView: View {
             card.displayName.lowercased().contains(query)
                 || card.maskedNumber.contains(query)
                 || card.brandName.lowercased().contains(query)
+                || card.healthStatus().rawValue.lowercased().contains(query)
         }
+    }
+
+    private var portfolioSummary: CardPortfolioSummary {
+        CardPortfolioSummary(cards: store.cards)
     }
 
     private static let logFormatter: DateFormatter = {
@@ -239,12 +244,19 @@ struct ContentView: View {
         List {
             if !store.cards.isEmpty {
                 Section("Summary") {
-                    summaryRow(title: "Cards on file", value: "\(store.cards.count)")
-                    summaryRow(title: "Total balance", value: formattedBalance(totalBalance()))
-                    if let average = averageBalance() {
+                    summaryRow(title: "Cards on file", value: "\(portfolioSummary.totalCards)")
+                    summaryRow(title: "Active cards", value: "\(portfolioSummary.activeCards)")
+                    if portfolioSummary.attentionCount > 0 {
+                        summaryRow(title: "Needs attention", value: "\(portfolioSummary.attentionCount)")
+                    }
+                    summaryRow(title: "Total balance", value: formattedBalance(portfolioSummary.totalBalance))
+                    if let average = portfolioSummary.averageBalance {
                         summaryRow(title: "Average balance", value: formattedBalance(average))
                     }
-                    summaryRow(title: "Brands", value: brandSummary())
+                    if let highest = portfolioSummary.highestBalanceCard {
+                        summaryRow(title: "Highest balance", value: "\(highest.displayName) • \(formattedBalance(highest.balance))")
+                    }
+                    summaryRow(title: "Brands", value: portfolioSummary.brandSummary)
                 }
             }
 
@@ -265,8 +277,18 @@ struct ContentView: View {
                         VStack(alignment: .leading, spacing: 4) {
                             Text(card.displayName)
                                 .font(.headline)
-                            Text("Brand: \(card.brandName)")
-                                .foregroundStyle(.secondary)
+                            HStack(spacing: 8) {
+                                Text("Brand: \(card.brandName)")
+                                    .foregroundStyle(.secondary)
+                                Text(card.healthStatus().rawValue)
+                                    .font(.caption)
+                                    .fontWeight(.semibold)
+                                    .padding(.horizontal, 8)
+                                    .padding(.vertical, 3)
+                                    .background(statusColor(for: card.healthStatus()).opacity(0.15))
+                                    .foregroundStyle(statusColor(for: card.healthStatus()))
+                                    .clipShape(Capsule())
+                            }
                             Text("Number: \(masked(card.number))")
                             Text("Expiry: \(card.expiryMonth)/\(card.expiryYear)  CVV: \(card.cvv)")
                                 .foregroundStyle(.secondary)
@@ -378,23 +400,15 @@ struct ContentView: View {
         pendingClearAction = nil
     }
 
-    private func totalBalance() -> Decimal {
-        store.cards.reduce(Decimal.zero) { $0 + $1.balance }
-    }
-
-    private func averageBalance() -> Decimal? {
-        guard !store.cards.isEmpty else { return nil }
-        let total = totalBalance()
-        let count = Decimal(store.cards.count)
-        return total / count
-    }
-
-    private func brandSummary() -> String {
-        let grouped = Dictionary(grouping: store.cards, by: { $0.brandName })
-        return grouped
-            .map { "\($0.key): \($0.value.count)" }
-            .sorted()
-            .joined(separator: " • ")
+    private func statusColor(for status: CardHealthStatus) -> Color {
+        switch status {
+        case .active:
+            return .green
+        case .expiringSoon:
+            return .orange
+        case .expired, .invalidNumber:
+            return .red
+        }
     }
 
     private func trimLogsIfNeeded() {

--- a/Sources/BankAppCore/CardAnalytics.swift
+++ b/Sources/BankAppCore/CardAnalytics.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+public enum CardHealthStatus: String, Codable, Equatable {
+    case active = "Active"
+    case expiringSoon = "Expiring Soon"
+    case expired = "Expired"
+    case invalidNumber = "Invalid Number"
+}
+
+public struct CardPortfolioSummary {
+    public let totalCards: Int
+    public let activeCards: Int
+    public let expiredCards: Int
+    public let expiringSoonCards: Int
+    public let invalidCards: Int
+    public let totalBalance: Decimal
+    public let averageBalance: Decimal?
+    public let highestBalanceCard: Card?
+    public let brandCounts: [String: Int]
+
+    public var attentionCount: Int {
+        expiredCards + expiringSoonCards + invalidCards
+    }
+
+    public init(cards: [Card], referenceDate: Date = Date(), calendar: Calendar = .current) {
+        totalCards = cards.count
+        totalBalance = cards.reduce(Decimal.zero) { $0 + $1.balance }
+        averageBalance = cards.isEmpty ? nil : totalBalance / Decimal(cards.count)
+        highestBalanceCard = cards.max { $0.balance < $1.balance }
+        brandCounts = Dictionary(grouping: cards, by: { $0.brandName }).mapValues(\.count)
+
+        var active = 0
+        var expired = 0
+        var expiringSoon = 0
+        var invalid = 0
+
+        for card in cards {
+            switch card.healthStatus(referenceDate: referenceDate, calendar: calendar) {
+            case .active:
+                active += 1
+            case .expiringSoon:
+                expiringSoon += 1
+            case .expired:
+                expired += 1
+            case .invalidNumber:
+                invalid += 1
+            }
+        }
+
+        activeCards = active
+        expiredCards = expired
+        expiringSoonCards = expiringSoon
+        invalidCards = invalid
+    }
+
+    public var brandSummary: String {
+        brandCounts
+            .map { "\($0.key): \($0.value)" }
+            .sorted()
+            .joined(separator: " • ")
+    }
+}
+
+public extension Card {
+    func healthStatus(referenceDate: Date = Date(), calendar: Calendar = .current, soonThresholdMonths: Int = 2) -> CardHealthStatus {
+        guard isLikelyValid else { return .invalidNumber }
+        guard !isExpired(referenceDate: referenceDate, calendar: calendar) else { return .expired }
+        guard let expiryDate = calendar.date(from: DateComponents(year: expiryYear, month: expiryMonth, day: 1)),
+              let thresholdDate = calendar.date(byAdding: .month, value: soonThresholdMonths, to: referenceDate) else {
+            return .expired
+        }
+        return expiryDate <= thresholdDate ? .expiringSoon : .active
+    }
+}

--- a/Tests/BankAppTests/CardAnalyticsTests.swift
+++ b/Tests/BankAppTests/CardAnalyticsTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import BankAppCore
+
+final class CardAnalyticsTests: XCTestCase {
+    private let calendar = Calendar(identifier: .gregorian)
+
+    func testCardHealthStatusPrioritizesInvalidNumbers() {
+        let card = Card(holderName: "A", prefix: "400000", number: "4000000000000000", expiryMonth: 12, expiryYear: 2030, cvv: "123", balance: 100)
+        let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 5, day: 8))!
+
+        XCTAssertEqual(card.healthStatus(referenceDate: referenceDate, calendar: calendar), .invalidNumber)
+    }
+
+    func testCardHealthStatusDetectsExpiredAndExpiringSoonCards() {
+        let expiredNumber = Luhn.generateCardNumber(prefix: "400000")!
+        let soonNumber = Luhn.generateCardNumber(prefix: "555555")!
+        let activeNumber = Luhn.generateCardNumber(prefix: "601111")!
+        let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 5, day: 8))!
+
+        let expired = Card(holderName: "Expired", prefix: "400000", number: expiredNumber, expiryMonth: 4, expiryYear: 2026, cvv: "123", balance: 100)
+        let soon = Card(holderName: "Soon", prefix: "555555", number: soonNumber, expiryMonth: 6, expiryYear: 2026, cvv: "123", balance: 200)
+        let active = Card(holderName: "Active", prefix: "601111", number: activeNumber, expiryMonth: 12, expiryYear: 2027, cvv: "123", balance: 300)
+
+        XCTAssertEqual(expired.healthStatus(referenceDate: referenceDate, calendar: calendar), .expired)
+        XCTAssertEqual(soon.healthStatus(referenceDate: referenceDate, calendar: calendar), .expiringSoon)
+        XCTAssertEqual(active.healthStatus(referenceDate: referenceDate, calendar: calendar), .active)
+    }
+
+    func testPortfolioSummaryCalculatesBalancesCountsAndAttentionItems() {
+        let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 5, day: 8))!
+        let active = Card(holderName: "Active", prefix: "400000", number: Luhn.generateCardNumber(prefix: "400000")!, expiryMonth: 12, expiryYear: 2027, cvv: "123", balance: 300)
+        let expiringSoon = Card(holderName: "Soon", prefix: "555555", number: Luhn.generateCardNumber(prefix: "555555")!, expiryMonth: 6, expiryYear: 2026, cvv: "123", balance: 200)
+        let invalid = Card(holderName: "Invalid", prefix: "999999", number: "9999999999999999", expiryMonth: 12, expiryYear: 2030, cvv: "123", balance: 100)
+
+        let summary = CardPortfolioSummary(cards: [active, expiringSoon, invalid], referenceDate: referenceDate, calendar: calendar)
+
+        XCTAssertEqual(summary.totalCards, 3)
+        XCTAssertEqual(summary.activeCards, 1)
+        XCTAssertEqual(summary.expiringSoonCards, 1)
+        XCTAssertEqual(summary.invalidCards, 1)
+        XCTAssertEqual(summary.attentionCount, 2)
+        XCTAssertEqual(summary.totalBalance, 600)
+        XCTAssertEqual(summary.averageBalance, 200)
+        XCTAssertEqual(summary.highestBalanceCard?.holderName, "Active")
+        XCTAssertEqual(summary.brandCounts["Visa"], 1)
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide portfolio-level health insights so users can quickly spot cards that are expired, expiring soon, invalid, or otherwise need attention.
- Surface health metadata in search and the dashboard summary to improve discoverability and actionable information in the UI.

### Description
- Added `Sources/BankAppCore/CardAnalytics.swift` introducing `CardHealthStatus`, `CardPortfolioSummary`, and a `Card.healthStatus(...)` extension to classify cards as `active`, `expiringSoon`, `expired`, or `invalidNumber`.
- Updated the SwiftUI dashboard at `Sources/BankApp/BankApp.swift` to include a `portfolioSummary` property, include health status in `filteredCards` search, present active/attention/highest-balance insights in the Summary, and show colored health-status badges per card with a `statusColor(for:)` helper.
- Added unit tests in `Tests/BankAppTests/CardAnalyticsTests.swift` covering health classification and portfolio summary calculations, and updated `README.md` to document health-status search and card health insights.

### Testing
- Ran `swift test` and all tests passed: 19 tests, 0 failures.
- Ran `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd7c6221ac832787a98bf2108c9a13)